### PR TITLE
http-watch email setup stage.

### DIFF
--- a/config-template
+++ b/config-template
@@ -11,3 +11,6 @@ NUMBEROFTRIES=NUMBEROFTRIESPLACEHOLDER
 
 # Command that is execute when action is required - An example would be: ACTION='service lsws restart'
 ACTION='ACTIONPLACEHOLDER'
+
+# Email which will be used to update
+EMAIL='EMAILPLACEHOLDER'

--- a/http-watch.sh
+++ b/http-watch.sh
@@ -51,7 +51,7 @@ do
 		$ACTION	
 		
 		# Dispatch Email Alert
-		echo "http-watch detected that $URL was offline for a sustained period and it took action by running: $ACTION" | mail -s "[http-watch] Site Offline" acawley@cloudabove.com
+		echo "http-watch detected that $URL was offline for a sustained period and it took action by running: $ACTION" | mail -s "[http-watch] Site Offline" $EMAIL
 
 		echo && echo "Service Restarted, pausing for $DELAY seconds before retrying..."
 		PAUSE

--- a/wizard-http-watch.sh
+++ b/wizard-http-watch.sh
@@ -74,7 +74,7 @@ else
         echo "User selected Cancel." && exit 1
 fi
 
-SUPPLIEDEMAIL=$(whiptail --inputbox "Please enter the email which we will use if the website goes offline:" 8 78 --title "HTTP-WATCH - Email" 3>&1 1>&2 2>&3)
+SUPPLIEDEMAIL=$(whiptail --inputbox "Email address to be notified:" 8 78 --title "HTTP-WATCH - Email" 3>&1 1>&2 2>&3)
 exitstatus=$?
 if [ $exitstatus = 0 ]; then
         sed -i "s,EMAILPLACEHOLDER,$SUPPLIEDEMAIL,g" config

--- a/wizard-http-watch.sh
+++ b/wizard-http-watch.sh
@@ -79,6 +79,7 @@ exitstatus=$?
 if [ $exitstatus = 0 ]; then
         sed -i "s,EMAILPLACEHOLDER,$SUPPLIEDEMAIL,g" config
 else
+	echo "User selected Cancel." && exit 1
 fi
 
 ## Reference ##

--- a/wizard-http-watch.sh
+++ b/wizard-http-watch.sh
@@ -74,6 +74,13 @@ else
         echo "User selected Cancel." && exit 1
 fi
 
+SUPPLIEDEMAIL=$(whiptail --inputbox "Please enter the email which we will use if the website goes offline:" 8 78 --title "HTTP-WATCH - Email" 3>&1 1>&2 2>&3)
+exitstatus=$?
+if [ $exitstatus = 0 ]; then
+        sed -i "s,EMAILPLACEHOLDER,$SUPPLIEDEMAIL,g" config
+else
+fi
+
 ## Reference ##
 # URL="URLPLACEHOLDER"
 # DELAY=DELAYPLACEHOLDER


### PR DESCRIPTION
Hi Ashley Cawley,

I have some changes inside of the http-watch project where you set what email to use inside of the watch script. This variable can be set using the wizard script which has a whiptail input box for an email to use if the website goes offline.

The final change was done inside of the 'config-template' file where a mail placeholder was added to use inside of the wizard script.

External testing was done over 'https://' to ensure that the tool is compatible with this particular protocol.

Warmest Regards.