### PR TITLE
http-watch logging

### DIFF
--- a/config-template
+++ b/config-template
@@ -19,4 +19,4 @@ EMAIL='EMAILPLACEHOLDER'
 LOGGING=1
 
 # Custom path for the Logging [ Do not add the trailing '/']
-LOG_PATH='/var/log/http-watch'
+LOG_PATH='/var/log/'

--- a/config-template
+++ b/config-template
@@ -19,4 +19,4 @@ EMAIL='EMAILPLACEHOLDER'
 LOGGING=1
 
 # Custom path for the Logging [ Do not add the trailing '/']
-LOG_PATH='/var/log/'
+LOG_PATH='/var/log'

--- a/config-template
+++ b/config-template
@@ -15,8 +15,8 @@ ACTION='ACTIONPLACEHOLDER'
 # Email which will be used to update
 EMAIL='EMAILPLACEHOLDER'
 
-# Enable Logging (Hidden in wizard) 1=Enable/0=Disable
+# Enable Logging (Hidden in wizard) 1=Enable/0=Disable (Will be revisited)
 LOGGING=1
 
-# Custom path for the Logging
+# Custom path for the Logging [ Do not add the trailing '/']
 LOG_PATH='/var/log/http-watch'

--- a/config-template
+++ b/config-template
@@ -14,3 +14,9 @@ ACTION='ACTIONPLACEHOLDER'
 
 # Email which will be used to update
 EMAIL='EMAILPLACEHOLDER'
+
+# Enable Logging (Hidden in wizard) 1=Enable/0=Disable
+LOGGING=1
+
+# Custom path for the Logging
+LOG_PATH='/var/log/http-watch'

--- a/http-watch.sh
+++ b/http-watch.sh
@@ -34,8 +34,8 @@ then
 	mkdir -p $LOG_PATH # If it does not, create the path from the config
 fi
 
-touch log_$URL.txt $LOG_PATH # Create a new log file
-LOG_FILE=$LOG_PATH/log_$URL.txt # Specify the path used to write
+touch log_http-watch.txt $LOG_PATH # Create a new log file
+LOG_FILE=$LOG_PATH/log_http-watch.txt # Specify the path used to write
 
 # Script
 

--- a/http-watch.sh
+++ b/http-watch.sh
@@ -28,7 +28,7 @@ log_running_date=`date '+%Y-%m-%d %H:%M:%S'`
 }
 
 function DATE {
-log_name_date=`date +'%Y-%m-%d'`
+log_name_date=`date +'%Y%m%d'`
 }
 
 # Pre-Script Checks
@@ -38,6 +38,7 @@ then
 	mkdir -p $LOG_PATH # If it does not, create the path from the config
 fi
 
+DATE # Get the date
 touch log_$log_name_date.txt $LOG_PATH # Create a new log file
 log_file=$LOG_PATH/log_$log_name_date.txt # Specify the path used to write
 

--- a/http-watch.sh
+++ b/http-watch.sh
@@ -32,16 +32,8 @@ log_running_date=`date '+%Y-%m-%d %H:%M:%S'`
 if [ ! -d "$LOG_PATH" ] # Check to see if the path exists
 then
 	mkdir $LOG_PATH # If it does not, create the path from the config
-fi
-
-if [ $LOGGING = "1" ]
-then
 	touch log_tmp.txt $LOG_PATH
 	log_file=$LOG_PATH/log_tmp.txt
-elif [ $LOGGING = "0" ]
-then
-	touch log_tmp.txt ./
-	log_file=./log_tmp.txt
 fi
 
 # Script
@@ -59,7 +51,7 @@ TESTURL # Performs intial test to see if URL is online and get its status code
 while [ $STATUSCODE == "200" ]
 do
 	LOG_DATE
-	echo "$log_running_date - Status code was 200, Everything is operational" >> $log_file
+	echo "$log_running_date - Website is online..." >> $log_file
 	# echo "200 - OK" # Debugging
 	PAUSE # Pauses for x number of seconds (specified by the user)
 	#ECHORETRIES # Debugging
@@ -68,7 +60,7 @@ do
 	while [ $STATUSCODE != "200" ] && [ $NUMBEROFTRIES -gt 0 ]
 	do
 		LOG_DATE
-		echo "$log_running_date - Website Offline... Testing again..." >> $log_file
+		echo "$log_running_date - Website Offline... Trying again..." >> $log_file
 		#NORESPONSE # Debugging
 		#ECHORETRIES # Debugging
 		PAUSE
@@ -81,7 +73,7 @@ do
 		LOG_DATE
 		#NORESPONSE # Debugging
 		$ACTION	
-		echo "$log_running_date - Action was needed because the site was offline, command executed: $ACTION" >> $log_file
+		echo "$log_running_date - Action was needed because the site was offline, command that was executed: $ACTION" >> $log_file
 
 		# Dispatch Email Alert
 		LOG_DATE
@@ -97,31 +89,23 @@ do
 		then
 			LOG_DATE
 			STATE=false
-			echo "$log_running_date - Site still offline..." >> $log_file
+			echo "$log_running_date - Website is still offline..." >> $log_file
 		fi
 		
 		while [ $STATE == "false" ]
 		do	
 			LOG_DATE
 			$ACTION
-			echo "$log_running_date - Site still offline... Re-running command..." >> $log_file
+			echo "$log_running_date - Website is still offline... Re-running action command..." >> $log_file
 			PAUSE
 			TESTURL
 			if [ $STATUSCODE == "200" ]
 			then
 				LOG_DATE
 				STATE=true
-				echo "$log_running_date - Site is back online!" >> $log_file
+				echo "$log_running_date - Website is back online!" >> $log_file
 			fi
 		done
 	fi
 	NUMBEROFTRIES=($SAVENUM) # Resets the NUMBEROFTRIES counter backs to its original number
 done
-
-if [ $LOGGING = "1" ]
-then
-	echo "Log file saved at - $log_file"
-elif [ $LOGGING = "0" ]
-then
-	rm ./log_tmp.txt
-fi

--- a/http-watch.sh
+++ b/http-watch.sh
@@ -28,7 +28,7 @@ log_running_date=`date '+%Y-%m-%d %H:%M:%S'`
 }
 
 function DATE {
-log_name_date=`date +%Y-%m-%d`
+log_name_date=`date +'%Y-%m-%d'`
 }
 
 # Pre-Script Checks

--- a/http-watch.sh
+++ b/http-watch.sh
@@ -34,7 +34,7 @@ then
 	mkdir -p $LOG_PATH # If it does not, create the path from the config
 fi
 
-touch http-watch.log $LOG_PATH # Create a new log file
+touch $LOG_PATH/http-watch.log  # Create a new log file
 LOG_FILE=$LOG_PATH/http-watch.log # Specify the path used to write
 
 # Script

--- a/http-watch.sh
+++ b/http-watch.sh
@@ -27,10 +27,6 @@ function LOG_DATE {
 log_running_date=`date '+%Y-%m-%d %H:%M:%S'`
 }
 
-function DATE {
-log_name_date=`date +'%Y%m%d'`
-}
-
 # Pre-Script Checks
 
 if [ ! -d "$LOG_PATH" ] # Check to see if the path exists
@@ -38,17 +34,15 @@ then
 	mkdir -p $LOG_PATH # If it does not, create the path from the config
 fi
 
-DATE # Get the date
-touch log_$log_name_date.txt $LOG_PATH # Create a new log file
-log_file=$LOG_PATH/log_$log_name_date.txt # Specify the path used to write
+touch log_$URL.txt $LOG_PATH # Create a new log file
+LOG_FILE=$LOG_PATH/log_$URL.txt # Specify the path used to write
 
 # Script
 
-echo "----- http-watch log file for: $URL -----"$'\r' > $log_file # New header 
-log_get_exe_date=`date '+%Y-%m-%d %H:%M:%S'` # Get current time with Hours, Mins, Seconds
-log_get_user=`whoami` # Get the user who executed the script
-echo "Script executed: $log_get_exe_date" >> $log_file # Write execute time to log
-echo "User running: $log_get_user" >> $log_file # Write user that executed the script to the log
+echo "----- http-watch log file -----"$'\r' > $LOG_FILE # New header 
+LOG_DATE # Get current time with Hours, Mins, Seconds
+echo "Script executed: $log_running_date" >> $LOG_FILE # Write execute time to log
+echo "User running: `whoami`" >> $LOG_FILE # Write user that executed the script to the log
 
 echo -e "\nHTTP-WATCH is monitoring: $URL"
 
@@ -64,7 +58,7 @@ do
 	while [ $STATUSCODE != "200" ] && [ $NUMBEROFTRIES -gt 0 ]
 	do
 		LOG_DATE
-		echo "$log_running_date - $URL is offline... Trying again..." >> $log_file
+		echo "$log_running_date - $URL is offline... Trying again..." >> $LOG_FILE
 		#NORESPONSE # Debugging
 		#ECHORETRIES # Debugging
 		PAUSE
@@ -77,37 +71,37 @@ do
 		LOG_DATE
 		#NORESPONSE # Debugging
 		$ACTION	
-		echo "$log_running_date - Action was needed because the $URL was offline, command that was executed: $ACTION" >> $log_file
+		echo "$log_running_date - Action was needed because the $URL was offline, command that was executed: $ACTION" >> $LOG_FILE
 
 		# Dispatch Email Alert
 		LOG_DATE
 		echo -e "[http-watch] reporting from `hostname` at `date` \n \nDetected that $URL was offline.\n \nThe following action was taken: $ACTION" | mail -s "[http-watch] $URL" $EMAIL
-		echo "$log_running_date - Email was dispatched to: $EMAIL" >> $log_file
+		echo "$log_running_date - Email was dispatched to: $EMAIL" >> $LOG_FILE
 
 		LOG_DATE
 		echo && echo "Service Restarted, pausing for $DELAY seconds before retrying..."
-		echo "$log_running_date - Service was restarted..." >> $log_file
+		echo "$log_running_date - Service was restarted..." >> $LOG_FILE
 		PAUSE
 		TESTURL
 		if [ $STATUSCODE != "200" ]
 		then
 			LOG_DATE
 			STATE=false
-			echo "$log_running_date - $URL is still offline..." >> $log_file
+			echo "$log_running_date - $URL is still offline..." >> $LOG_FILE
 		fi
 		
 		while [ $STATE == "false" ]
 		do	
 			LOG_DATE
 			$ACTION
-			echo "$log_running_date - $URL is still offline... Re-running action command..." >> $log_file
+			echo "$log_running_date - $URL is still offline... Re-running action command..." >> $LOG_FILE
 			PAUSE
 			TESTURL
 			if [ $STATUSCODE == "200" ]
 			then
 				LOG_DATE
 				STATE=true
-				echo "$log_running_date - $URL is back online!" >> $log_file
+				echo "$log_running_date - $URL is back online!" >> $LOG_FILE
 			fi
 		done
 	fi

--- a/http-watch.sh
+++ b/http-watch.sh
@@ -27,23 +27,27 @@ function LOG_DATE {
 log_running_date=`date '+%Y-%m-%d %H:%M:%S'`
 }
 
+function DATE {
+log_name_date=`date '+%Y-%m-%d'`
+}
+
 # Pre-Script Checks
 
 if [ ! -d "$LOG_PATH" ] # Check to see if the path exists
 then
-	mkdir $LOG_PATH # If it does not, create the path from the confi
+	mkdir -p $LOG_PATH # If it does not, create the path from the config
 fi
 
-touch log_tmp.txt $LOG_PATH
-log_file=$LOG_PATH/log_tmp.txt
+touch log_$log_name_date.txt $LOG_PATH # Create a new log file
+log_file=$LOG_PATH/log_$log_name_date.txt # Specify the path used to write
 
 # Script
 
-echo "----- http-watch log file -----"$'\r' > $log_file
-log_get_exe_date=`date '+%Y-%m-%d %H:%M:%S'`
-log_get_user=`whoami`
-echo "Script executed: $log_get_exe_date" >> $log_file
-echo "User running: $log_get_user" >> $log_file
+echo "----- http-watch log file for: $URL -----"$'\r' > $log_file # New header 
+log_get_exe_date=`date '+%Y-%m-%d %H:%M:%S'` # Get current time with Hours, Mins, Seconds
+log_get_user=`whoami` # Get the user who executed the script
+echo "Script executed: $log_get_exe_date" >> $log_file # Write execute time to log
+echo "User running: $log_get_user" >> $log_file # Write user that executed the script to the log
 
 echo -e "\nHTTP-WATCH is monitoring: $URL"
 
@@ -51,8 +55,6 @@ TESTURL # Performs intial test to see if URL is online and get its status code
 
 while [ $STATUSCODE == "200" ]
 do
-	LOG_DATE
-	echo "$log_running_date - Website is online..." >> $log_file
 	# echo "200 - OK" # Debugging
 	PAUSE # Pauses for x number of seconds (specified by the user)
 	#ECHORETRIES # Debugging
@@ -61,7 +63,7 @@ do
 	while [ $STATUSCODE != "200" ] && [ $NUMBEROFTRIES -gt 0 ]
 	do
 		LOG_DATE
-		echo "$log_running_date - Website Offline... Trying again..." >> $log_file
+		echo "$log_running_date - $URL is offline... Trying again..." >> $log_file
 		#NORESPONSE # Debugging
 		#ECHORETRIES # Debugging
 		PAUSE
@@ -74,7 +76,7 @@ do
 		LOG_DATE
 		#NORESPONSE # Debugging
 		$ACTION	
-		echo "$log_running_date - Action was needed because the site was offline, command that was executed: $ACTION" >> $log_file
+		echo "$log_running_date - Action was needed because the $URL was offline, command that was executed: $ACTION" >> $log_file
 
 		# Dispatch Email Alert
 		LOG_DATE
@@ -90,21 +92,21 @@ do
 		then
 			LOG_DATE
 			STATE=false
-			echo "$log_running_date - Website is still offline..." >> $log_file
+			echo "$log_running_date - $URL is still offline..." >> $log_file
 		fi
 		
 		while [ $STATE == "false" ]
 		do	
 			LOG_DATE
 			$ACTION
-			echo "$log_running_date - Website is still offline... Re-running action command..." >> $log_file
+			echo "$log_running_date - $URL is still offline... Re-running action command..." >> $log_file
 			PAUSE
 			TESTURL
 			if [ $STATUSCODE == "200" ]
 			then
 				LOG_DATE
 				STATE=true
-				echo "$log_running_date - Website is back online!" >> $log_file
+				echo "$log_running_date - $URL is back online!" >> $log_file
 			fi
 		done
 	fi

--- a/http-watch.sh
+++ b/http-watch.sh
@@ -31,10 +31,11 @@ log_running_date=`date '+%Y-%m-%d %H:%M:%S'`
 
 if [ ! -d "$LOG_PATH" ] # Check to see if the path exists
 then
-	mkdir $LOG_PATH # If it does not, create the path from the config
-	touch log_tmp.txt $LOG_PATH
-	log_file=$LOG_PATH/log_tmp.txt
+	mkdir $LOG_PATH # If it does not, create the path from the confi
 fi
+
+touch log_tmp.txt $LOG_PATH
+log_file=$LOG_PATH/log_tmp.txt
 
 # Script
 

--- a/http-watch.sh
+++ b/http-watch.sh
@@ -28,7 +28,7 @@ log_running_date=`date '+%Y-%m-%d %H:%M:%S'`
 }
 
 function DATE {
-log_name_date=`date '+%Y-%m-%d'`
+log_name_date=`date +%Y-%m-%d`
 }
 
 # Pre-Script Checks

--- a/http-watch.sh
+++ b/http-watch.sh
@@ -34,8 +34,8 @@ then
 	mkdir -p $LOG_PATH # If it does not, create the path from the config
 fi
 
-touch log_http-watch.txt $LOG_PATH # Create a new log file
-LOG_FILE=$LOG_PATH/log_http-watch.txt # Specify the path used to write
+touch http-watch.log $LOG_PATH # Create a new log file
+LOG_FILE=$LOG_PATH/http-watch.log # Specify the path used to write
 
 # Script
 

--- a/http-watch.sh
+++ b/http-watch.sh
@@ -23,7 +23,34 @@ function NORESPONSE {
 echo "Error: URL Not Responding"
 }
 
+function LOG_DATE {
+log_running_date=`date '+%Y-%m-%d %H:%M:%S'`
+}
+
+# Pre-Script Checks
+
+if [ ! -d "$LOG_PATH" ] # Check to see if the path exists
+then
+	mkdir $LOG_PATH # If it does not, create the path from the config
+fi
+
+if [ $LOGGING = "1" ]
+then
+	touch log_tmp.txt $LOG_PATH
+	log_file=$LOG_PATH/log_tmp.txt
+elif [ $LOGGING = "0" ]
+then
+	touch log_tmp.txt ./
+	log_file=./log_tmp.txt
+fi
+
 # Script
+
+echo "----- http-watch log file -----"$'\r' > $log_file
+log_get_exe_date=`date '+%Y-%m-%d %H:%M:%S'`
+log_get_user=`whoami`
+echo "Script executed: $log_get_exe_date" >> $log_file
+echo "User running: $log_get_user" >> $log_file
 
 echo -e "\nHTTP-WATCH is monitoring: $URL"
 
@@ -31,6 +58,8 @@ TESTURL # Performs intial test to see if URL is online and get its status code
 
 while [ $STATUSCODE == "200" ]
 do
+	LOG_DATE
+	echo "$log_running_date - Status code was 200, Everything is operational" >> $log_file
 	# echo "200 - OK" # Debugging
 	PAUSE # Pauses for x number of seconds (specified by the user)
 	#ECHORETRIES # Debugging
@@ -38,6 +67,8 @@ do
 	
 	while [ $STATUSCODE != "200" ] && [ $NUMBEROFTRIES -gt 0 ]
 	do
+		LOG_DATE
+		echo "$log_running_date - Website Offline... Testing again..." >> $log_file
 		#NORESPONSE # Debugging
 		#ECHORETRIES # Debugging
 		PAUSE
@@ -47,31 +78,50 @@ do
 
 	if [ $NUMBEROFTRIES == "0" ]
 	then
+		LOG_DATE
 		#NORESPONSE # Debugging
 		$ACTION	
-		
-		# Dispatch Email Alert
-		echo -e "[http-watch] reporting from `hostname` at `date` \n \nDetected that $URL was offline.\n \nThe following action was taken: $ACTION" | mail -s "[http-watch] $URL" $EMAIL
+		echo "$log_running_date - Action was needed because the site was offline, command executed: $ACTION" >> $log_file
 
+		# Dispatch Email Alert
+		LOG_DATE
+		echo -e "[http-watch] reporting from `hostname` at `date` \n \nDetected that $URL was offline.\n \nThe following action was taken: $ACTION" | mail -s "[http-watch] $URL" $EMAIL
+		echo "$log_running_date - Email was dispatched to: $EMAIL" >> $log_file
+
+		LOG_DATE
 		echo && echo "Service Restarted, pausing for $DELAY seconds before retrying..."
+		echo "$log_running_date - Service was restarted..." >> $log_file
 		PAUSE
 		TESTURL
 		if [ $STATUSCODE != "200" ]
 		then
+			LOG_DATE
 			STATE=false
+			echo "$log_running_date - Site still offline..." >> $log_file
 		fi
 		
 		while [ $STATE == "false" ]
-		do
+		do	
+			LOG_DATE
 			$ACTION
+			echo "$log_running_date - Site still offline... Re-running command..." >> $log_file
 			PAUSE
 			TESTURL
 			if [ $STATUSCODE == "200" ]
 			then
+				LOG_DATE
 				STATE=true
+				echo "$log_running_date - Site is back online!" >> $log_file
 			fi
 		done
 	fi
 	NUMBEROFTRIES=($SAVENUM) # Resets the NUMBEROFTRIES counter backs to its original number
 done
 
+if [ $LOGGING = "1" ]
+then
+	echo "Log file saved at - $log_file"
+elif [ $LOGGING = "0" ]
+then
+	rm ./log_tmp.txt
+fi


### PR DESCRIPTION
Hi Ashley,

Happy New Year!

Following my previous pull request, I have made further changes to include a logging system to log when the chosen target stops responding or goes offline. This logging system does not log when the website test comes back successful.

You can change the directory inside the config file after running the wizard script. Keep in mind, that this option was designed to be forced so there is no options inside of the wizard to enable or disable logging. 

The logging system logs what time the script was executed and who executed the script. The log file it's self contains the date of the log entry (YYYY-MM-DD HH-MM-SS -) followed by the url and it's status. 

Kind Regards,
Thomas Keast.