### PR TITLE
Improved Wizard & Process Check

### DIFF
--- a/http-watch.sh
+++ b/http-watch.sh
@@ -30,7 +30,7 @@ log_running_date=`date '+%Y-%m-%d %H:%M:%S'`
 # Pre-Script Checks
 
 SCRIPT_NAME=`basename "$0"`
-GET_PID=$(pidof -x $SCRIPT_NAME)
+GET_PID=$(pidof -x "$SCRIPT_NAME")
 if [ $GET_PID == "" ]
 then
 	CLONE=0

--- a/http-watch.sh
+++ b/http-watch.sh
@@ -31,7 +31,7 @@ log_running_date=`date '+%Y-%m-%d %H:%M:%S'`
 
 SCRIPT_NAME=`basename "$0"`
 GET_PID=$(pidof -x "$SCRIPT_NAME")
-if [ $GET_PID == "" ]
+if [ $GET_PID == $$ ] 2> /dev/null
 then
 	CLONE=0
 else

--- a/http-watch.sh
+++ b/http-watch.sh
@@ -29,15 +29,15 @@ log_running_date=`date '+%Y-%m-%d %H:%M:%S'`
 
 # Pre-Script Checks
 
-SCRIPT_NAME=`basename "$0"`
-GET_PID=$(pidof -x "$SCRIPT_NAME")
-if [ $GET_PID == $$ ] 2> /dev/null
+SCRIPT_NAME=`basename "$0"` # Get script name
+GET_PID=$(pidof -x "$SCRIPT_NAME") # Check the script name to see if it is running
+if [ $GET_PID == $$ ] 2> /dev/null # If the process ID is the same as this instance
 then
-	CLONE=0
+	sleep 1 # Wait for 1 second
 else
-	whiptail --title "http-watch.sh - Script already running!" --msgbox "http-watch is already running! Please stop the other instance before continuing.. The process ID: $GET_PID" 8 78
-	CLONE=1
-	exit 1
+	GET_PID=${GET_PID//$$/} # Remove it's own instance from $GET_PID
+	whiptail --title "http-watch.sh - Script already running!" --msgbox "http-watch is already running! Please stop the other instance before continuing.. The process ID: $GET_PID" 8 78 # Display message box and show the other process Id
+	exit 1 # Quit the script 
 fi
 
 if [ ! -d "$LOG_PATH" ] # Check to see if the path exists

--- a/http-watch.sh
+++ b/http-watch.sh
@@ -29,6 +29,17 @@ log_running_date=`date '+%Y-%m-%d %H:%M:%S'`
 
 # Pre-Script Checks
 
+SCRIPT_NAME=`basename "$0"`
+GET_PID=$(pidof -x $SCRIPT_NAME)
+if [ $GET_PID == "" ]
+then
+	CLONE=0
+else
+	whiptail --title "http-watch.sh - Script already running!" --msgbox "http-watch is already running! Please stop the other instance before continuing.. The process ID: $GET_PID" 8 78
+	CLONE=1
+	exit 1
+fi
+
 if [ ! -d "$LOG_PATH" ] # Check to see if the path exists
 then
 	mkdir -p $LOG_PATH # If it does not, create the path from the config

--- a/http-watch.sh
+++ b/http-watch.sh
@@ -43,6 +43,7 @@ echo "----- http-watch log file -----" >> $LOG_FILE # New header
 LOG_DATE # Get current time with Hours, Mins, Seconds
 echo "Script executed: $log_running_date" >> $LOG_FILE # Write execute time to log
 echo "User running: `whoami`" >> $LOG_FILE # Write user that executed the script to the log
+echo "HTTP-WATCH is monitoring: $URL" >> $LOG_FILE # Write the URL which is being watched
 
 echo -e "\nHTTP-WATCH is monitoring: $URL"
 

--- a/wizard-http-watch.sh
+++ b/wizard-http-watch.sh
@@ -99,26 +99,34 @@ CONFIRM='                              Is the supplied information correct?
                               ACTION SET:        '$SUPPLIEDACTION'
                               EMAIL SET:         '$SUPPLIEDEMAIL''
 
-if (whiptail --title "Confirm Config" --yesno "$CONFIRM" 25 100)
+if (whiptail --title "HTTP-Wizard - Confirm Config" --yesno "$CONFIRM" 25 100)
 then
-	whiptail --title "Config Saved!" --msgbox "The config file has now been saved!" 8 78
-	exit 0
+	whiptail --title "HTTP-Wizard - Config Saved!" --msgbox "The config file has now been saved!" 8 78
 else
-	if (whiptail --title "Start over?" --yesno "Would you like to restart the script?" 8 78)
+	if (whiptail --title "HTTP-Wizard - Start over?" --yesno "Would you like to restart the script?" 8 78)
 	then
 		clear
 		./wizard-http-watch.sh
 	else
-		if (whiptail --title "Delete current config?" --yesno "Would you like to delete the current config?" 8 78)
+		if (whiptail --title "HTTP-Wizard - Delete current config?" --yesno "Would you like to delete the current config?" 8 78)
 		then
 			rm -f config
-			whiptail --title "Config Deleted!" --msgbox "Config file has been deleted!" 8 78
+			whiptail --title "HTTP-Wizard - Config Deleted!" --msgbox "Config file has been deleted!" 8 78
 			exit 0
 		else
-			whiptail --title "Config Saved!" --msgbox "Config files has been saved!" 8 78
-			exit 0
+			whiptail --title "HTTP-Wizard - Config Saved!" --msgbox "Config files has been saved!" 8 78
 		fi
 	fi
+fi
+
+if (whiptail --title "HTTP-Watch - Start the script?" --yesno "Would you like to start the main script? (http-watch.sh)" 8 78)
+then
+	echo "Closing wizard-http-watch.sh.."
+	./http-watch.sh &
+	exit 0
+else
+	whiptail --title "HTTP-Wizard - Script finished!" --msgbox "The script has completed! I will not start http-watch..." 8 78
+	exit 0
 fi
 
 ## Reference ##

--- a/wizard-http-watch.sh
+++ b/wizard-http-watch.sh
@@ -82,6 +82,45 @@ else
 	echo "User selected Cancel." && exit 1
 fi
 
+# Testing for whiptail.
+#SUPPLIEDURL=""
+#SUPPLIEDDELAY="3"
+#SUPPLIEDRETRIES="3"
+#SUPPLIEDACTION="service apache2 restart"
+#SUPPLIEDEMAIL=""
+
+CONFIRM='                              Is the supplied information correct?
+
+                            ========================================
+
+                              URL:               '$SUPPLIEDURL'
+                              DELAY SET:         '$SUPPLIEDDELAY'
+                              RETRY LIMIT:       '$SUPPLIEDRETRIES'
+                              ACTION SET:        '$SUPPLIEDACTION'
+                              EMAIL SET:         '$SUPPLIEDEMAIL''
+
+if (whiptail --title "Confirm Config" --yesno "$CONFIRM" 25 100)
+then
+	whiptail --title "Config Saved!" --msgbox "The config file has now been saved!" 8 78
+	exit 0
+else
+	if (whiptail --title "Start over?" --yesno "Would you like to restart the script?" 8 78)
+	then
+		clear
+		./wizard-http-watch.sh
+	else
+		if (whiptail --title "Delete current config?" --yesno "Would you like to delete the current config?" 8 78)
+		then
+			rm -f config
+			whiptail --title "Config Deleted!" --msgbox "Config file has been deleted!" 8 78
+			exit 0
+		else
+			whiptail --title "Config Saved!" --msgbox "Config files has been saved!" 8 78
+			exit 0
+		fi
+	fi
+fi
+
 ## Reference ##
 # URL="URLPLACEHOLDER"
 # DELAY=DELAYPLACEHOLDER


### PR DESCRIPTION
Hi Ashley,

I've tested my latest build and it's all working correctly, I have made a few changes which I hope will be beneficial to the project.

### **Process  Check**
Disabled the script from running multiple times. This check uses the `basename` command along with `pidof` to check to see if the process is already running. After, it performs an IF statement to check to see if the instance is it's just it's self, if it is, It will run the script as normal. 

However, if there is another instance running under a different PID (Not it's own), it will display a whiptail menu saying that it's already running and will display the other PID (And removes it self from the output). 

### **Improved the Wizard**
Since my latest build, I have added a whiptail menu where you can preview the config before it saves. This function will help prevent human typos from you having to manually restart and remove the old config file. 

Additionally, there is now an option to start the script right after the config has been made/saved. If you press "yes" it will start the script in the background and will proceed like normal.

### **Misc**
- Added the URL to the log underneath the `whoami` line. 2d51fb3
- Added comments to the process check. e09b723

I had a lot of fun working on this build, I look forward to spending more time on the project.  